### PR TITLE
[grandorder] _SimulatorPools Collection Added

### DIFF
--- a/app/_custom/collections/_simulator-pools.ts
+++ b/app/_custom/collections/_simulator-pools.ts
@@ -1,0 +1,54 @@
+import type { CollectionConfig } from "payload/types";
+
+import { isStaff } from "../../db/collections/users/users.access";
+
+export const _SimulatorPools: CollectionConfig = {
+   slug: "_simulator-pools",
+   labels: { singular: "_Simulator-Pool", plural: "_Simulator-Pools" },
+   admin: { group: "Custom", useAsTitle: "name" },
+
+   access: {
+      create: isStaff, //udpate in future to allow site admins as well
+      read: () => true,
+      update: isStaff, //udpate in future to allow site admins as well
+      delete: isStaff, //udpate in future to allow site admins as well
+   },
+   fields: [
+      {
+         name: "id",
+         type: "text",
+      },
+      {
+         name: "name",
+         type: "text",
+      },
+      {
+         name: "servants",
+         type: "relationship",
+         relationTo: "servants",
+         hasMany: true,
+      },
+      {
+         name: "craft_essences",
+         type: "relationship",
+         relationTo: "craft-essences",
+         hasMany: true,
+      },
+      {
+         name: "materials",
+         type: "relationship",
+         relationTo: "materials",
+         hasMany: true,
+      },
+      {
+         name: "command_codes",
+         type: "relationship",
+         relationTo: "command-codes",
+         hasMany: true,
+      },
+      {
+         name: "checksum",
+         type: "text",
+      },
+   ],
+};

--- a/app/_custom/collections/index.ts
+++ b/app/_custom/collections/index.ts
@@ -29,6 +29,7 @@ import { _NPClassifications } from "./_np-classifications";
 import { _QuestTypes } from "./_quest-types";
 import { _Rarities } from "./_rarities";
 import { _ReleaseStatuses } from "./_release-statuses";
+import { _SimulatorPools } from "./_simulator-pools";
 import { _SkillClassificationSpecifics } from "./_skill-classification-specifics";
 import { _SkillImages } from "./_skill-images";
 import { _StarRarities } from "./_star-rarities";
@@ -103,6 +104,7 @@ export const CustomCollections = [
    _QuestTypes,
    _Rarities,
    _ReleaseStatuses,
+   _SimulatorPools,
    _SkillClassificationSpecifics,
    _SkillImages,
    _StarRarities,
@@ -111,4 +113,3 @@ export const CustomCollections = [
    _Targets,
    _Traits,
 ];
-


### PR DESCRIPTION
- Used for defining Servants and Craft Essences/Materials/Command Codes available in summon simulator pools to avoid hardcoding these in the sim code.