### PR TITLE
[grandorder] Command Code template + Servant fixes

### DIFF
--- a/app/_custom/routes/_site.c.command-codes+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.command-codes+/$entryId.tsx
@@ -1,0 +1,96 @@
+// Core Imports
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { gql } from "graphql-request";
+
+import { CommandCodesEffect } from "~/_custom/routes/_site.c.command-codes+/components/CommandCodes.Effect";
+import { CommandCodesMain } from "~/_custom/routes/_site.c.command-codes+/components/CommandCodes.Main";
+import { CommandCodesSimilar } from "~/_custom/routes/_site.c.command-codes+/components/CommandCodes.Similar";
+import type { CommandCode as CommandCodeType } from "~/db/payload-custom-types";
+import { Entry } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/Entry";
+import { entryMeta } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/entryMeta";
+import { fetchEntry } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/fetchEntry.server";
+
+export { entryMeta as meta };
+
+export async function loader({
+   context: { payload, user },
+   params,
+   request,
+}: LoaderFunctionArgs) {
+   const { entry } = await fetchEntry({
+      payload,
+      params,
+      request,
+      user,
+      gql: {
+         query: QUERY,
+      },
+   });
+   return json({
+      entry,
+   });
+}
+
+const SECTIONS = {
+   main: CommandCodesMain,
+   effect: CommandCodesEffect,
+   similar: CommandCodesSimilar,
+};
+
+export default function EntryPage() {
+   const { entry } = useLoaderData<typeof loader>();
+   const cc = entry?.data?.CommandCode as CommandCodeType;
+
+   return <Entry customComponents={SECTIONS} customData={cc} />;
+}
+
+const QUERY = gql`
+   query ($entryId: String!) {
+      CommandCode(id: $entryId) {
+         id
+         name
+         command_code_id
+         desc_effect
+         acquisition_method
+         illustrator {
+            name
+         }
+         icon {
+            url
+         }
+         image {
+            url
+         }
+         rarity {
+            name
+         }
+         effect_image {
+            icon {
+               url
+            }
+         }
+         effect_list {
+            effect {
+               name
+               icon {
+                  url
+               }
+               cc_With_Effect {
+                  id
+                  slug
+                  name
+                  rarity {
+                     name
+                  }
+                  icon {
+                     url
+                  }
+               }
+            }
+         }
+         slug
+      }
+   }
+`;

--- a/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Effect.tsx
+++ b/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Effect.tsx
@@ -1,0 +1,53 @@
+import type { CommandCode as CommandCodeType } from "payload/generated-custom-types";
+import { Image } from "~/components/Image";
+import { SectionTitle } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/SectionTitle";
+
+export function CommandCodesEffect({ data: cc }: { data: CommandCodeType }) {
+   const dispData = [
+      {
+         header: "Effect",
+         value: cc?.desc_effect,
+         image: cc?.effect_image?.icon?.url,
+      },
+      {
+         header: "Acquisition Method",
+         value: cc?.acquisition_method,
+      },
+   ];
+
+   return (
+      <>
+         {dispData.map((data) => {
+            return (
+               <>
+                  <SectionTitle customTitle={data.header} />
+                  {data?.value && (
+                     <div className="flex items-start gap-4 border border-color-sub rounded-lg shadow-1 shadow-sm bg-2-sub p-3">
+                        {data.image ? (
+                           <Image
+                              width={128}
+                              height={128}
+                              //@ts-ignore
+                              url={data?.image}
+                              alt="skill_icon"
+                              loading="lazy"
+                              className="size-12 flex-none"
+                           />
+                        ) : null}
+                        <div className="flex-grow">
+                           {/* Description */}
+                           <div
+                              className="text-sm whitespace-pre-wrap"
+                              dangerouslySetInnerHTML={{
+                                 __html: data.value ?? "",
+                              }}
+                           ></div>
+                        </div>
+                     </div>
+                  )}
+               </>
+            );
+         })}
+      </>
+   );
+}

--- a/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Main.tsx
+++ b/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Main.tsx
@@ -1,0 +1,48 @@
+import type { CommandCode as CommandCodeType } from "payload/generated-custom-types";
+import { Image } from "~/components/Image";
+
+export function CommandCodesMain({ data: cc }: { data: CommandCodeType }) {
+   const mainStatDisplay = [
+      {
+         label: "ID",
+         value: cc.command_code_id,
+      },
+      {
+         label: "Rarity",
+         value: cc.rarity?.name + "★",
+      },
+      {
+         label: "Illustrator",
+         value: cc.illustrator?.name,
+      },
+   ];
+
+   return (
+      <div className="tablet:flex max-tablet:flex-col items-start gap-3 pb-4">
+         <div className="tablet:w-[340px]">
+            <Image
+               width={680}
+               className="rounded-md max-laptop:w-full"
+               url={cc?.image?.url}
+               alt={cc?.name ?? ""}
+            />
+         </div>
+         <div
+            className="border border-color-sub divide-y divide-color-sub shadow-sm shadow-1 rounded-lg flex-grow
+         mb-3 [&>*:nth-of-type(odd)]:bg-zinc-50 dark:[&>*:nth-of-type(odd)]:bg-dark350 overflow-hidden"
+         >
+            {mainStatDisplay?.map((row) => (
+               <div
+                  key={row.value}
+                  className="p-3 justify-between flex items-center gap-2"
+               >
+                  <div className="flex items-center gap-2">
+                     <span className="font-semibold text-sm">{row.label}</span>
+                  </div>
+                  <div className="text-sm font-semibold">{row.value}</div>
+               </div>
+            ))}
+         </div>
+      </div>
+   );
+}

--- a/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Similar.tsx
+++ b/app/_custom/routes/_site.c.command-codes+/components/CommandCodes.Similar.tsx
@@ -1,0 +1,68 @@
+import { Fragment } from "react";
+
+import { Link } from "@remix-run/react";
+
+import type { CommandCode as CommandCodeType } from "payload/generated-custom-types";
+import { Image } from "~/components/Image";
+import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/Tooltip";
+
+export function CommandCodesSimilar({ data: cc }: { data: CommandCodeType }) {
+   return (
+      <div className="space-y-6">
+         {cc.effect_list?.map((eff: any) => {
+            const name = eff.effect?.name;
+            const icon = eff.effect.icon?.url;
+            const cclist = eff.effect.cc_With_Effect;
+            return (
+               <>
+                  {cclist?.length > 0 ? (
+                     <div key={name}>
+                        <div className="bg-3-sub border border-color-sub rounded-lg shadow-sm shadow-1 mb-2 p-2 flex items-center gap-3">
+                           {icon ? (
+                              <Image
+                                 width={48}
+                                 height={48}
+                                 className="object-contain size-9 rounded-md"
+                                 url={icon}
+                                 alt="skill_icon"
+                                 loading="lazy"
+                              />
+                           ) : null}
+                           <div className="flex-grow font-bold">
+                              {/* Description */}
+                              {name}
+                           </div>
+                        </div>
+                        <div className="">
+                           {cclist.map((c: any) => {
+                              return (
+                                 <Tooltip key={c?.id} placement="top">
+                                    <TooltipTrigger className="size-12 inline-block align-middle m-0.5">
+                                       <Link
+                                          to={`/c/command-codes/${
+                                             c?.slug ?? c?.id
+                                          }`}
+                                       >
+                                          <Image
+                                             height={"auto"}
+                                             width={60}
+                                             className="overflow-clip text-xs"
+                                             url={c?.icon?.url}
+                                             alt={c?.name}
+                                             loading="lazy"
+                                          />
+                                       </Link>
+                                    </TooltipTrigger>
+                                    <TooltipContent>{c?.name}</TooltipContent>
+                                 </Tooltip>
+                              );
+                           })}
+                        </div>
+                     </div>
+                  ) : null}
+               </>
+            );
+         })}
+      </div>
+   );
+}

--- a/app/_custom/routes/_site.c.servants+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.servants+/$entryId.tsx
@@ -51,6 +51,7 @@ export async function loader({
       servant: entry?.data?.Servant,
       ceData: entry?.data?.CraftEssences?.docs,
       bannerData: entry?.data?.SummonEvents?.docs,
+      costumeData: entry?.data?.Costumes?.docs,
    });
 }
 
@@ -467,6 +468,15 @@ const QUERY = gql`
                   name
                }
                banner_reference
+            }
+         }
+      }
+      Costumes(where: { servant: { equals: $jsonEntryId } }) {
+         docs {
+            id
+            name
+            icon {
+               url
             }
          }
       }

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Main.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Main.tsx
@@ -7,8 +7,14 @@ import { Icon } from "~/components/Icon";
 import { Image } from "~/components/Image";
 import type { Servant } from "~/db/payload-custom-types";
 
-export function ServantsMain({ data }: { data: { servant: Servant } }) {
+export function ServantsMain({
+   data,
+}: {
+   data: { servant: Servant; costumeData: any };
+}) {
    const servant = data.servant;
+   const costumes = data.costumeData;
+   console.log(costumes);
 
    const traitlist = servant?.traits;
 
@@ -16,7 +22,7 @@ export function ServantsMain({ data }: { data: { servant: Servant } }) {
 
    return (
       <div>
-         <ServantImageBaseData charData={servant} />
+         <ServantImageBaseData charData={servant} costumeData={costumes} />
          {traitlist && traitlist?.length > 0 ? (
             <>
                <h3 className="flex items-center dark:text-zinc-100 max-laptop:mt-3 mt-1 gap-3 pb-1.5 font-header text-lg">
@@ -77,7 +83,13 @@ export function ServantsMain({ data }: { data: { servant: Servant } }) {
 // =====================================
 // 2) Servant Image and Base Data
 // =====================================
-function ServantImageBaseData({ charData }: { charData: Servant }) {
+function ServantImageBaseData({
+   charData,
+   costumeData,
+}: {
+   charData: Servant;
+   costumeData: any;
+}) {
    // Initialize list of selectable images for a Servant (4 stages by default; additional images can be appended to this object for costumes)
    let selectimg = [
       {
@@ -97,6 +109,14 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
          url: charData.image_stage_4?.url,
       },
    ];
+   const costumeimg = costumeData?.map((cost) => {
+      return {
+         name: cost.name,
+         url: cost.icon?.url,
+      };
+   });
+   console.log(costumeimg);
+   selectimg.push(...costumeimg);
 
    // UseState variable to track selected display image for Servant
    const [characterImage, setCharacterImage] = useState(selectimg[0]?.name);
@@ -164,6 +184,20 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
 
    return (
       <>
+         {/* Header - Class and Rarity */}
+         <div className="flex items-center shadow-sm shadow-1 border border-color-sub py-2 pl-2 pr-3 rounded-lg bg-2-sub mb-2">
+            <div className="flex-grow font-bold">
+               <div className="relative inline-block align-middle size-7">
+                  <Image width={40} height={40} url={classicon} />
+               </div>
+               <div className="relative inline-block align-middle font-bold ml-2 w-2/5">
+                  {classname}
+               </div>
+            </div>
+            <div className="flex-none">
+               <StarRarity key={id} rar={rarityno} />
+            </div>
+         </div>
          <div className="tablet:flex max-tablet:flex-col items-start gap-3 pb-4">
             <section className="space-y-0.5 max-tablet:pb-3 tablet:max-w-[340px]">
                {/* Servant Image */}
@@ -172,11 +206,11 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
                   to={imgUrl ?? ""}
                   className="relative block"
                >
-                  <div className="tablet:w-[340px]">
+                  <div className="tablet:w-[340px] min-h-[250px]">
                      <Image
                         width={680}
                         className="rounded-md max-laptop:w-full"
-                        url={imgUrl}
+                        url={imgUrl ?? ""}
                         alt={charData?.name ?? "Servant Image"}
                      />
                   </div>
@@ -193,7 +227,7 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
                   </div>
                </Link>
                {/* - Image Selection */}
-               <div className="grid grid-cols-2 laptop:grid-cols-4 gap-2 py-2">
+               <div className="grid grid-cols-2 laptop:grid-cols-2 gap-2 py-2">
                   {selectimg.map((opt: any) => {
                      return (
                         <>
@@ -212,49 +246,14 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
                      );
                   })}
                </div>
-               <div
-                  className="border border-color-sub divide-y divide-color-sub shadow-sm shadow-1 rounded-lg 
-               mb-3 overflow-hidden bg-2-sub"
-               >
-                  <div className="px-2.5 py-3 justify-between flex items-center gap-2 text-xs">
-                     <div className="flex items-center gap-2">
-                        <span className="font-semibold">Attribute</span>
-                     </div>
-                     <div className="font-semibold text-1 text-right">
-                        {attribute}
-                     </div>
-                  </div>
-                  <div className="px-2.5 py-3 justify-between flex items-center gap-2 text-xs">
-                     <div className="flex items-center gap-2">
-                        <span className="font-semibold">Alignments</span>
-                     </div>
-                     <div className="font-semibold text-1 text-right">
-                        {alignment}
-                     </div>
-                  </div>
-               </div>
             </section>
             {/* Right Data Block */}
             <div className="flex-grow space-y-3">
-               {/* Header - Class and Rarity */}
-               <div className="flex items-center shadow-sm shadow-1 border border-color-sub py-2 pl-2 pr-3 rounded-lg bg-2-sub">
-                  <div className="flex-grow font-bold">
-                     <div className="relative inline-block align-middle size-7">
-                        <Image width={40} height={40} url={classicon} />
-                     </div>
-                     <div className="relative inline-block align-middle font-bold ml-2 w-2/5">
-                        {classname}
-                     </div>
-                  </div>
-                  <div className="flex-none">
-                     <StarRarity key={id} rar={rarityno} />
-                  </div>
-               </div>
                {/* - Hit count */}
                <div className="flex items-center justify-evenly shadow-sm shadow-1 border border-color-sub py-2 rounded-lg bg-2-sub">
                   {hitcounts.map((hit: any, i: any) => (
                      <div key={hit.id} className="relative">
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center align-middle gap-2">
                            <div className="h-auto w-8">
                               <Image height={64} url={hit.img} alt="CardType" />
                            </div>
@@ -264,12 +263,33 @@ function ServantImageBaseData({ charData }: { charData: Servant }) {
                                  <Image height={64} url={nptype} alt="NP" />
                               </div>
                            ) : null}
-                        </div>
-                        <div className="text-xs font-bold rounded-full dark:bg-dark500 size-4 flex items-center justify-center absolute -right-3 bottom-0">
-                           {hit.hits ?? "-"}
+                           <div className="text-xs font-bold rounded-full dark:bg-dark500 size-4 flex items-center justify-center absolute -right-4 bottom-[8px]">
+                              {hit.hits ?? "-"}
+                           </div>
                         </div>
                      </div>
                   ))}
+               </div>
+               <div
+                  className="border border-color-sub divide-y divide-color-sub shadow-sm shadow-1 rounded-lg 
+               mb-3 overflow-hidden bg-2-sub"
+               >
+                  <div className="px-2.5 py-2 justify-between flex items-center gap-2 text-xs">
+                     <div className="flex items-center gap-2">
+                        <span className="font-semibold">Attribute</span>
+                     </div>
+                     <div className="font-semibold text-1 text-right">
+                        {attribute}
+                     </div>
+                  </div>
+                  <div className="px-2.5 py-2 justify-between flex items-center gap-2 text-xs">
+                     <div className="flex items-center gap-2">
+                        <span className="font-semibold">Alignments</span>
+                     </div>
+                     <div className="font-semibold text-1 text-right">
+                        {alignment}
+                     </div>
+                  </div>
                </div>
                <TableNPGainStar data={charData} />
                <TableHPATK data={charData} />
@@ -358,9 +378,9 @@ function TableHPATK({ data: servant }: { data: Servant }) {
    return (
       <>
          <div className="space-y-3">
-            <div className="bg-2-sub shadow-sm shadow-1 border border-color-sub rounded-lg p-3">
-               <div className="font-bold text-sm flex items-center gap-2 pb-2">
-                  <span className="font-mono text-sm">Attack</span>
+            <div className="bg-2-sub shadow-sm shadow-1 border border-color-sub rounded-lg py-2 px-3">
+               <div className="font-bold text-sm flex items-center gap-2 pb-1">
+                  <span className="font-mono text-base">Attack</span>
                   <span className="flex-grow h-0.5 rounded-full dark:bg-dark450 bg-zinc-100" />
                </div>
                <div className="text-sm flex items-center justify-evenly gap-3">
@@ -405,9 +425,9 @@ function TableHPATK({ data: servant }: { data: Servant }) {
                   </div>
                </div>
             </div>
-            <div className="bg-2-sub shadow-sm shadow-1 border border-color-sub rounded-lg p-3">
-               <div className="font-bold text-sm flex items-center gap-2 pb-2">
-                  <span className="font-mono text-sm">HP</span>
+            <div className="bg-2-sub shadow-sm shadow-1 border border-color-sub rounded-lg py-2 px-3">
+               <div className="font-bold text-sm flex items-center gap-2 pb-1">
+                  <span className="font-mono text-base">HP</span>
                   <span className="flex-grow h-0.5 rounded-full dark:bg-dark450 bg-zinc-100" />
                </div>
                <div className="text-sm flex items-center justify-evenly gap-3">
@@ -513,7 +533,7 @@ function TableNPGainStar({ data: servant }: { data: Servant }) {
             className="border border-color-sub divide-y divide-color-sub shadow-sm shadow-1 rounded-lg 
                mb-3 [&>*:nth-of-type(odd)]:bg-zinc-50 dark:[&>*:nth-of-type(odd)]:bg-dark350 overflow-hidden"
          >
-            <div className="p-3 justify-between flex items-center gap-2">
+            <div className="p-2 justify-between flex items-center gap-2">
                <div className="flex items-center  gap-2">
                   <Image
                      className="size-5"

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Materials.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Materials.tsx
@@ -187,7 +187,7 @@ export function TotalMaterials({ data }: any) {
 
    return (
       <>
-         <Table grid framed dense>
+         <Table grid framed dense className="!whitespace-normal">
             <TableBody>
                {displayTotals?.map((row, index) => (
                   <TableRow key={index}>
@@ -195,7 +195,7 @@ export function TotalMaterials({ data }: any) {
                         {row.name}
                      </TableHeader>
                      <TableCell>
-                        <div className="w-full">
+                        <div className="">
                            {row.data?.map((mat, key) => (
                               <MaterialQtyFrame
                                  materialqty={mat}

--- a/app/_custom/routes/_site.c.servants+/components/Servants.NoblePhantasm.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.NoblePhantasm.tsx
@@ -51,7 +51,7 @@ const NoblePhantasmDisplay = ({ np }: any) => {
                />
                <div className="space-y-1 flex-grow">
                   <div className="flex items-center justify-between pb-0.5">
-                     <div className="flex items-center gap-2 text-sm font-mono">
+                     <div className="flex items-center gap-2 text-base">
                         <span className="font-bold">{np_name}</span>
                         <span className="text-1">{np_rank}</span>
                      </div>

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Profile.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Profile.tsx
@@ -131,7 +131,7 @@ function Parameters({ data: servant }: { data: ServantType }) {
             {paramlist?.map((p: any) => {
                return (
                   <>
-                     <div className="w-full flex items-center justify-left gap-2">
+                     <div className="w-full flex justify-left gap-2">
                         <div className="flex-none w-7 font-mono font-bold">
                            {p.name}
                         </div>
@@ -157,7 +157,7 @@ function Parameters({ data: servant }: { data: ServantType }) {
                               );
                            })}
                         </div>
-                        <div className="w-6 ml-1 font-bold">{p.grade}</div>
+                        <div className="w-8 ml-1 font-bold">{p.grade}</div>
                      </div>
                   </>
                );

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Skills.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Skills.tsx
@@ -109,9 +109,7 @@ const SkillDisplay = ({ skill }: any) => {
                alt="SkillIcon"
             />
             <div className="flex-grow">
-               <div className="font-bold text-sm font-mono pb-0.5">
-                  {skill_name}
-               </div>
+               <div className="font-bold text-base pb-0.5">{skill_name}</div>
                <div
                   className="text-sm whitespace-pre-wrap pb-1"
                   dangerouslySetInnerHTML={{
@@ -327,9 +325,7 @@ function AppendSkillDisplay({ skill }: any) {
                   alt="SkillIcon"
                />
                <div className="flex-grow">
-                  <div className="font-bold text-sm font-mono">
-                     {skill_name}
-                  </div>
+                  <div className="font-bold text-base">{skill_name}</div>
                   <div
                      className="text-sm whitespace-pre-wrap pb-1.5"
                      dangerouslySetInnerHTML={{
@@ -403,9 +399,7 @@ const ClassSkillDisplay = ({ skill }: any) => {
                   alt="SkillIcon"
                />
                <div className="flex-grow">
-                  <div className="font-bold font-mono text-sm pb-0.5">
-                     {skill_name}
-                  </div>
+                  <div className="font-bold text-base pb-0.5">{skill_name}</div>
                   <div
                      className="text-sm whitespace-pre-wrap"
                      dangerouslySetInnerHTML={{

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Writeup.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Writeup.tsx
@@ -206,31 +206,31 @@ const SkillRecCircle = ({ rec }: any) => {
       case "Higher":
          return (
             <Badge className="justify-center w-full" color="teal">
-               Best
+               Higher
             </Badge>
          );
       case "High":
          return (
             <Badge className="justify-center w-full" color="green">
-               Great
+               High
             </Badge>
          );
       case "Medium":
          return (
             <Badge className="justify-center w-full" color="lime">
-               Ok
+               Med
             </Badge>
          );
       case "Low":
          return (
             <Badge className="justify-center w-full" color="orange">
-               Decent
+               Low
             </Badge>
          );
       case "Lower":
          return (
             <Badge className="justify-center w-full" color="red">
-               Meh
+               Lower
             </Badge>
          );
       default:


### PR DESCRIPTION
Command Code entry template created:
- Main / Effect / CCs with similar effects sections added, borrowed from Craft Essence layout.

Servants:
- Added Costume as selectable image, reordered Main section
- Updated appearance and font formatting for skills/NP
- Updated wrap behavior for Total Ascension Materials section
- Writeup section annotation changed to Higher/High/Med/Low/Lower to match prior text