### PR TITLE
[grandorder] Enemy Entry Templating + minor fixes

### DIFF
--- a/app/_custom/routes/_site.c.enemies+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.enemies+/$entryId.tsx
@@ -1,0 +1,68 @@
+// Core Imports
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { gql } from "graphql-request";
+
+import { EnemiesMain } from "~/_custom/routes/_site.c.enemies+/components/Enemies.Main";
+import type { Enemy as EnemyType } from "~/db/payload-custom-types";
+import { Entry } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/Entry";
+import { entryMeta } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/entryMeta";
+import { fetchEntry } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/fetchEntry.server";
+
+export { entryMeta as meta };
+
+export async function loader({
+   context: { payload, user },
+   params,
+   request,
+}: LoaderFunctionArgs) {
+   const { entry } = await fetchEntry({
+      payload,
+      params,
+      request,
+      user,
+      gql: {
+         query: QUERY,
+      },
+   });
+   return json({
+      entry,
+   });
+}
+
+const SECTIONS = {
+   main: EnemiesMain,
+};
+
+export default function EntryPage() {
+   const { entry } = useLoaderData<typeof loader>();
+   const enemy = entry?.data?.Enemy as EnemyType;
+
+   return <Entry customComponents={SECTIONS} customData={enemy} />;
+}
+
+const QUERY = gql`
+   query ($entryId: String!) {
+      Enemy(id: $entryId) {
+         id
+         name
+         desc_skills
+         desc_np
+         icon {
+            url
+         }
+         class_rarity {
+            name
+            icon {
+               url
+            }
+         }
+         traits {
+            id
+            name
+         }
+         slug
+      }
+   }
+`;

--- a/app/_custom/routes/_site.c.enemies+/components/Enemies.Main.tsx
+++ b/app/_custom/routes/_site.c.enemies+/components/Enemies.Main.tsx
@@ -1,0 +1,123 @@
+import type { Enemy as EnemyType } from "payload/generated-custom-types";
+import { Image } from "~/components/Image";
+
+export function EnemiesMain({ data: enemy }: { data: Enemy }) {
+   return (
+      <>
+         <div className="tablet:flex items-center gap-3 border border-color-sub rounded-md p-3">
+            <div className="">
+               <Image
+                  width={50}
+                  className="rounded-md "
+                  url={enemy?.icon?.url}
+                  alt={"Icon"}
+               />
+            </div>
+            <div className="text-lg">{enemy?.name}</div>
+            <div>
+               <Image
+                  width={30}
+                  className="rounded-md "
+                  url={enemy.class_rarity?.icon?.url}
+                  alt={"Icon enemy.class_rarity?.name"}
+               />
+            </div>
+         </div>
+         <TraitList enemy={enemy} />
+         <Skills enemy={enemy} />
+      </>
+   );
+}
+
+const TraitList = ({ enemy }: any) => {
+   const traitlist = enemy.traits;
+   return (
+      <>
+         {traitlist && traitlist?.length > 0 ? (
+            <>
+               <h3 className="flex items-center dark:text-zinc-100 mt-3 gap-3 pb-1.5 font-header text-lg">
+                  <div className="min-w-[10px] flex-none">Traits</div>
+                  <div className="h-1 flex-grow rounded-full bg-zinc-100 dark:bg-dark400" />
+               </h3>
+               {traitlist.map((trait: any, tkey) => {
+                  return (
+                     <>
+                        <div
+                           className="inline-flex text-sm font-semibold bg-2-sub gap-1 mr-2 rounded-lg px-2.5 py-1.5 mb-2 
+                           border-color-sub border shadow-sm shadow-1"
+                           key={"trait_list_" + tkey}
+                        >
+                           {trait.name}
+                        </div>
+                     </>
+                  );
+               })}
+            </>
+         ) : null}
+      </>
+   );
+};
+
+const Skills = ({ enemy }: any) => {
+   const desc_skill = enemy.desc_skills;
+   const desc_np = enemy.desc_np;
+
+   return (
+      <>
+         {desc_skill ? (
+            <>
+               <h3 className="flex items-center dark:text-zinc-100 mt-3 gap-3 pb-1.5 font-header text-lg">
+                  <div className="min-w-[10px] flex-none">Skills</div>
+                  <div className="h-1 flex-grow rounded-full bg-zinc-100 dark:bg-dark400" />
+               </h3>
+               <div
+                  className="bg-2-sub border-color-sub border px-2.5 py-1.5 rounded-md"
+                  dangerouslySetInnerHTML={{ __html: desc_skill }}
+               ></div>
+            </>
+         ) : null}
+         {desc_np ? (
+            <>
+               <h3 className="flex items-center dark:text-zinc-100 mt-3 gap-3 pb-1.5 font-header text-lg">
+                  <div className="min-w-[10px] flex-none">NP</div>
+                  <div className="h-1 flex-grow rounded-full bg-zinc-100 dark:bg-dark400" />
+               </h3>
+               <div
+                  className="bg-2-sub border-color-sub border px-2.5 py-1.5 rounded-md"
+                  dangerouslySetInnerHTML={{ __html: desc_np }}
+               ></div>
+            </>
+         ) : null}
+      </>
+   );
+};
+
+const MaterialFrame = ({ materialqty }: any) => {
+   const mat = materialqty?.material;
+   const qty = materialqty?.qty;
+
+   return (
+      <>
+         <div
+            className="relative inline-block text-center mr-0.5 mb-1"
+            key={mat?.id}
+         >
+            <a href={`/c/materials/${mat?.id}`}>
+               <div className="relative inline-block h-12 w-12 align-middle text-xs">
+                  <img
+                     src={mat?.icon?.url ?? "no_image_42df124128"}
+                     className={`object-contain h-12`}
+                     alt={mat?.name}
+                     loading="lazy"
+                  />
+               </div>
+               {qty ? (
+                  <div className="absolute z-10 -bottom-0.5 right-2 text-sm text-white grandorder-material-qty">
+                     {qty}
+                  </div>
+               ) : null}
+            </a>
+         </div>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.quests+/components/Quests.Enemies.tsx
+++ b/app/_custom/routes/_site.c.quests+/components/Quests.Enemies.tsx
@@ -18,9 +18,9 @@ export function QuestsEnemies({ data }: { data: any }) {
               qind == 0
                  ? true
                  : quest_details[qind]?.quest_parts !=
-                     quest_details[qind - 1]?.quest_parts
-                   ? true
-                   : false; // Controls whether the "Part" label should show up - Always show first
+                   quest_details[qind - 1]?.quest_parts
+                 ? true
+                 : false; // Controls whether the "Part" label should show up - Always show first
 
            return (
               <div key={qd}>
@@ -188,7 +188,7 @@ function EnemyAlternative({ data }: { data: any }) {
                width={48}
                height={48}
                className="size-6"
-               url={class_icon}
+               url={enemy_icon}
                alt="icon"
                loading="lazy"
             />
@@ -196,7 +196,7 @@ function EnemyAlternative({ data }: { data: any }) {
                width={48}
                height={48}
                className="size-6"
-               url={enemy_icon}
+               url={class_icon}
                alt="icon"
                loading="lazy"
             />

--- a/app/_custom/routes/_site.c.quests+/components/Quests.Rewards.tsx
+++ b/app/_custom/routes/_site.c.quests+/components/Quests.Rewards.tsx
@@ -74,11 +74,10 @@ const RewardRow = ({ data, index }: any) => {
                            >
                               {name}
                            </div>
+                           <Badge className="!text-sm">x{qty}</Badge>
                            <Badge>
-                              x{qty}
                               {rate ? (
                                  <>
-                                    <span className="size-1 bg-zinc-400 dark:bg-zinc-500 rounded-full" />
                                     <span>{rate}%</span>
                                  </>
                               ) : null}

--- a/app/_custom/routes/_site.c.servants+/components/Servants.Skills.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Skills.tsx
@@ -119,7 +119,7 @@ const SkillDisplay = ({ skill }: any) => {
                   }}
                ></div>
                <div
-                  className="text-xs text-1 italic pb-1.5"
+                  className="border-t text-xs border-color-sub py-2 mt-2"
                   dangerouslySetInnerHTML={{ __html: unlock }}
                />
                <button
@@ -215,9 +215,9 @@ const SkillUpgrade = ({ skill }: any) => {
                alt="SkillIcon"
             />
             <div className="flex-grow">
-               <div className="font-bold font-mono text-sm">{skill_name}</div>
+               <div className="font-bold text-base pb-0.5">{skill_name}</div>
                <div
-                  className="text-xs whitespace-pre-wrap"
+                  className="text-sm whitespace-pre-wrap"
                   dangerouslySetInnerHTML={{
                      __html: skill_description
                         .replace(


### PR DESCRIPTION
Enemy template added to show:
- Icon/Name/Class header
- Trait list
- Skill and NP if applicable

![image](https://github.com/user-attachments/assets/7a7dfa28-3435-40e7-a0c3-77167821b787)

Additional fixes -
Quests:
- Alternative enemy icon fixed to show before class icon
- Reward list quantity separated from drop rate badge
Servants:
- Skill upgrade formatting fixed to match normal skills