### PR TITLE
[grandorder] Quest template - Fixes to list element formatting

### DIFF
--- a/app/_custom/routes/_site.c.quests+/components/Quests.Main.tsx
+++ b/app/_custom/routes/_site.c.quests+/components/Quests.Main.tsx
@@ -35,8 +35,14 @@ export function QuestsMain({ data }: { data: any }) {
       },
    ];
 
+   // For proper formatting of inline ul elements in description!
+   const formatting = `<style>
+   ul {list-style-type: disc;margin: 0 0 .75em 25px;}
+   </style>`;
+
    return (
       <>
+         <div dangerouslySetInnerHTML={{ __html: formatting }}></div>
          <Table grid framed dense>
             <TableBody>
                {info?.map((irow: any, ind: any) => {


### PR DESCRIPTION
For example page, see:
https://grandorder.gamepress.gg/c/quests/94076901

Before:
![image](https://github.com/user-attachments/assets/95dfe1e0-fb0c-4043-9af0-b1aff5ce89ca)

After:
![image](https://github.com/user-attachments/assets/73b09780-3b6d-40e0-8bc0-f8633da8583c)
