### PR TITLE
[grandorder] Mystic Code Templating completed

### DIFF
--- a/app/_custom/routes/_site.c.mystic-codes+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.mystic-codes+/$entryId.tsx
@@ -1,0 +1,80 @@
+// Core Imports
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { gql } from "graphql-request";
+
+import type { MysticCode as MysticCodeType } from "~/db/payload-custom-types";
+import { Entry } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/Entry";
+import { entryMeta } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/entryMeta";
+import { fetchEntry } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/fetchEntry.server";
+
+import { MysticCodesMain } from "./components/MysticCodes.Main";
+import { MysticCodesSkills } from "./components/MysticCodes.Skills";
+import { MysticCodesOverview } from "./components/MysticCodes.Overview";
+import { MysticCodesExp } from "./components/MysticCodes.Exp";
+
+export { entryMeta as meta };
+
+export async function loader({
+   context: { payload, user },
+   params,
+   request,
+}: LoaderFunctionArgs) {
+   const { entry } = await fetchEntry({
+      payload,
+      params,
+      request,
+      user,
+      gql: {
+         query: QUERY,
+      },
+   });
+   return json({
+      entry,
+   });
+}
+
+const SECTIONS = {
+   main: MysticCodesMain,
+   skills: MysticCodesSkills,
+   overview: MysticCodesOverview,
+   exp: MysticCodesExp,
+};
+
+export default function EntryPage() {
+   const { entry } = useLoaderData<typeof loader>();
+   const mc = entry?.data?.MysticCode as MysticCodeType;
+   //console.log(mc);
+
+   return <Entry customComponents={SECTIONS} customData={mc} />;
+}
+
+const QUERY = gql`
+   query ($entryId: String!) {
+      MysticCode(id: $entryId) {
+         id
+         name
+         slug
+         icon {
+            url
+         }
+         image_male {
+            url
+         }
+         skills {
+            name
+            cooldown
+            effect
+            effect_values
+            skill_image {
+               icon {
+                  url
+               }
+            }
+         }
+         level_exp
+         overview
+      }
+   }
+`;

--- a/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Exp.tsx
+++ b/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Exp.tsx
@@ -1,0 +1,51 @@
+import type { MysticCode } from "payload/generated-custom-types";
+import {
+   Table,
+   TableBody,
+   TableCell,
+   TableHead,
+   TableHeader,
+   TableRow,
+} from "~/components/Table";
+
+export const MysticCodesExp = ({ data }: { data: MysticCode }) => {
+   return (
+      <>
+         <ExpTable data={data} />
+      </>
+   );
+};
+
+const ExpTable = ({ data }: { data: MysticCode }) => {
+   const exp = data.level_exp;
+
+   return (
+      <>
+         <Table grid framed dense>
+            <TableHead>
+               <TableRow>
+                  <TableHeader center>Current Level</TableHeader>
+                  <TableHeader center>Next Level</TableHeader>
+                  <TableHeader center>Required EXP</TableHeader>
+               </TableRow>
+            </TableHead>
+            <TableBody>
+               {exp?.map((value: any, index: number) => (
+                  <TableRow key={index}>
+                     <TableCell center>{index + 1}</TableCell>
+                     <TableCell center>{value?.toLocaleString()}</TableCell>
+                     <TableCell center>
+                        {/* Calculate cumulative sum up to current level */}
+                        {/* @ts-ignore */}
+                        {exp
+                           .slice(0, index)
+                           ?.reduce((a, b) => a + b, 0)
+                           ?.toLocaleString()}
+                     </TableCell>
+                  </TableRow>
+               ))}
+            </TableBody>
+         </Table>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Main.tsx
+++ b/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Main.tsx
@@ -1,0 +1,43 @@
+import type { MysticCode } from "payload/generated-custom-types";
+import { Image } from "~/components/Image";
+
+export const MysticCodesMain = ({ data }: { data: MysticCode }) => {
+   const code = data;
+
+   let galleryname = ["Icon (Female)", "Icon (Male)"];
+   let gallerylist = [code?.icon?.url, code?.image_male?.url];
+
+   return (
+      <>
+         <div className="mb-3 grid w-full grid-cols-2 gap-3">
+            {galleryname.map((img, i) => {
+               const gimg = gallerylist[i];
+               return (
+                  gimg && (
+                     <div
+                        className="shadow-1 border-color-sub relative inline-block overflow-hidden rounded-lg border text-center shadow-sm"
+                        key={img}
+                     >
+                        <div className="border-color-sub bg-3-sub relative block border-b py-2 text-center text-sm font-bold">
+                           {img}
+                        </div>
+                        <a href={gimg}>
+                           <div className="bg-2-sub relative flex w-full items-center justify-center p-3">
+                              <div className="relative h-24 w-24 text-center">
+                                 <Image
+                                    options="aspect_ratio=1:1&height=120&width=120"
+                                    alt="Gallery Item"
+                                    url={gimg}
+                                    className="h-24 w-24 object-contain"
+                                 />
+                              </div>
+                           </div>
+                        </a>
+                     </div>
+                  )
+               );
+            })}
+         </div>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Overview.tsx
+++ b/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Overview.tsx
@@ -1,0 +1,26 @@
+import type { MysticCode } from "payload/generated-custom-types";
+
+export const MysticCodesOverview = ({ data }: { data: MysticCode }) => {
+   return (
+      <>
+         <OverviewText data={data} />
+      </>
+   );
+};
+
+const OverviewText = ({ data }: { data: MysticCode }) => {
+   const overview = data.overview;
+   const styling = `<style>
+   ul{list-style-type: disc;margin: 0 0 .75em 25px;} div{white-space:wrap;} p a {color: #448acb;} p{margin-bottom: 0.75rem;}
+   </style>`;
+
+   return (
+      <>
+         <div dangerouslySetInnerHTML={{ __html: styling }}></div>
+         <div
+            className="my-2 whitespace-wrap"
+            dangerouslySetInnerHTML={{ __html: overview }}
+         ></div>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Skills.tsx
+++ b/app/_custom/routes/_site.c.mystic-codes+/components/MysticCodes.Skills.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+
+import clsx from "clsx";
+
+import { Icon } from "~/components/Icon";
+import { Image } from "~/components/Image";
+
+const tablestyling = `
+   <style>
+   table.skill-table tr th {
+     text-align:center;
+     padding: 0.2rem;
+     font-size: 0.7rem;
+     border-width: 1px;
+     background-color: rgba(50,50,50,0.03);
+   }
+   .dark table.skill-table tr th {
+      border-color: rgba(250,250,250,0.1);
+      background-color: rgba(250,250,250,0.03);
+   }
+   table.skill-table tr td {
+     text-align:center;
+     padding: 0.2rem;
+     font-size: 0.7rem;
+     border-width: 1px;
+   }
+   .dark table.skill-table tr td {
+     border-color: rgba(250,250,250,0.1);
+   }
+   </style>
+   `;
+
+export function MysticCodesSkills({ data }: { data: any }) {
+   const code = data;
+   const skilllist = code?.skills;
+   console.log(code);
+
+   return (
+      <>
+         <div>
+            <div className="space-y-3">
+               {skilllist?.map((skill: any, si: number) => {
+                  return (
+                     <SkillDisplay skill={skill} key={"skill_display_" + si} />
+                  );
+               })}
+            </div>
+         </div>
+      </>
+   );
+}
+
+// =====================================
+// 1) Skill Display Component
+// =====================================
+const SkillDisplay = ({ skill }: any) => {
+   const skill_name = skill?.name;
+   const skill_icon = skill?.skill_image?.icon?.url;
+   const skill_value_table = skill?.effect_values;
+   const skill_description = skill?.effect;
+   const cd = skill.cooldown ?? 0;
+
+   const skilltablehtml = `
+   ${tablestyling}
+   <tr>
+   <th>Lvl</th>
+   <th>1</th>
+   <th>2</th>
+   <th>3</th>
+   <th>4</th>
+   <th>5</th>
+   <th>6</th>
+   <th>7</th>
+   <th>8</th>
+   <th>9</th>
+   <th>10</th>
+   </tr>
+   ${skill_value_table}
+   <tr>
+     <th>CD</th>
+     <td>${cd}</td>
+     <td>${cd}</td>
+     <td>${cd}</td>
+     <td>${cd}</td>
+     <td>${cd}</td>
+     <td>${cd - 1}</td>
+     <td>${cd - 1}</td>
+     <td>${cd - 1}</td>
+     <td>${cd - 1}</td>
+     <td>${cd - 2}</td>
+   </tr>`;
+   const [open, setOpen] = useState(false);
+
+   return (
+      <div className="p-3 border border-color-sub rounded-lg shadow-1 shadow-sm bg-zinc-50 dark:bg-dark350">
+         <div className="flex items-start gap-3">
+            <Image
+               className="size-10 mt-1"
+               height={80}
+               url={skill_icon}
+               alt="SkillIcon"
+            />
+            <div className="flex-grow">
+               <div className="font-bold text-base pb-0.5">{skill_name}</div>
+               <div
+                  className="text-sm whitespace-pre-wrap pb-1"
+                  dangerouslySetInnerHTML={{
+                     __html: skill_description
+                        .replace(/\<br\>/g, "")
+                        .replace(/\<p\>\r\n/g, "<p>"),
+                  }}
+               ></div>
+               <button
+                  onClick={() => setOpen(!open)}
+                  className={clsx(
+                     open
+                        ? "bg-blue-100 text-blue-600 border-blue-300 dark:text-blue-200 dark:bg-blue-900 dark:border-blue-800"
+                        : "bg-blue-50 border-blue-200 dark:text-blue-200 text-blue-400 dark:bg-blue-950 dark:border-blue-900",
+                     "flex items-center justify-between gap-1 text-[10px]  border rounded-md pl-2 pr-1 w-full py-1 font-bold",
+                  )}
+               >
+                  <div>Show Info</div>
+                  <Icon
+                     className={clsx(
+                        open
+                           ? "transform rotate-180 text-blue-500 dark:text-blue-200"
+                           : "dark:text-blue-300 ",
+                     )}
+                     size={16}
+                     name="chevron-down"
+                  />
+               </button>
+            </div>
+         </div>
+         {open ? (
+            <div className="overflow-auto">
+               <table
+                  className="text-xs text-center mt-3 w-full skill-table"
+                  dangerouslySetInnerHTML={{ __html: skilltablehtml }}
+               ></table>
+            </div>
+         ) : null}
+      </div>
+   );
+};


### PR DESCRIPTION
Subsections:
- Main (icons)
- Skills (three skills with expanding accordion, borrowed from updated Servants page)
- Overview (added styling formatting to handle proper display for HTML block)
- Experience Table

![image](https://github.com/user-attachments/assets/6d677147-73ff-4572-b2ee-f5ba4f3eb79b)
![image](https://github.com/user-attachments/assets/6e3a754d-3d65-48a0-afa5-429f3dbafec8)
