### PR TITLE
[grandorder] Tags templating and collection rename

### DIFF
--- a/app/_custom/collections/index.ts
+++ b/app/_custom/collections/index.ts
@@ -35,6 +35,7 @@ import { _SkillImages } from "./_skill-images";
 import { _StarRarities } from "./_star-rarities";
 import { _StatusEffects } from "./_status-effects";
 import { _Tags } from "./_tags";
+import { Tags } from "./tags";
 import { _Targets } from "./_targets";
 import { _Traits } from "./_traits";
 import { AppendSkills } from "./append-skills";
@@ -109,6 +110,7 @@ export const CustomCollections = [
    _SkillImages,
    _StarRarities,
    _StatusEffects,
+   Tags,
    _Tags,
    _Targets,
    _Traits,

--- a/app/_custom/collections/servants.ts
+++ b/app/_custom/collections/servants.ts
@@ -47,7 +47,7 @@ export const Servants: CollectionConfig = {
             {
                name: "tags",
                type: "relationship",
-               relationTo: "_tags",
+               relationTo: "tags",
                hasMany: true,
             },
          ],

--- a/app/_custom/collections/tags.ts
+++ b/app/_custom/collections/tags.ts
@@ -1,0 +1,49 @@
+import type { CollectionConfig } from "payload/types";
+
+import { isStaff } from "../../db/collections/users/users.access";
+
+export const Tags: CollectionConfig = {
+   slug: "tags",
+   labels: { singular: "Tag", plural: "Tags" },
+   admin: {
+      group: "Custom",
+      useAsTitle: "name",
+   },
+   access: {
+      create: isStaff, //udpate in future to allow site admins as well
+      read: () => true,
+      update: isStaff, //udpate in future to allow site admins as well
+      delete: isStaff, //udpate in future to allow site admins as well
+   },
+   fields: [
+      {
+         name: "id",
+         type: "text",
+      },
+      {
+         name: "drupal_tid",
+         type: "text",
+      },
+      {
+         name: "name",
+         type: "text",
+      },
+      {
+         name: "description",
+         type: "text",
+      },
+      {
+         name: "icon",
+         type: "upload",
+         relationTo: "images",
+      },
+      {
+         name: "slug",
+         type: "text",
+      },
+      {
+         name: "checksum",
+         type: "text",
+      },
+   ],
+};

--- a/app/_custom/routes/_site.c.tags+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.tags+/$entryId.tsx
@@ -1,0 +1,87 @@
+// Core Imports
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { gql } from "graphql-request";
+
+import type { Tag as TagType } from "~/db/payload-custom-types";
+import { Entry } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/Entry";
+import { entryMeta } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/entryMeta";
+import { fetchEntry } from "~/routes/_site+/c_+/$collectionId_.$entryId/utils/fetchEntry.server";
+
+import { TagsMain } from "./components/Tags.Main";
+import { TagsServants } from "./components/Tags.Servants";
+
+export { entryMeta as meta };
+
+export async function loader({
+   context: { payload, user },
+   params,
+   request,
+}: LoaderFunctionArgs) {
+   const { entry } = await fetchEntry({
+      payload,
+      params,
+      request,
+      user,
+      gql: {
+         query: QUERY,
+      },
+   });
+   return json({
+      entry,
+      tag: entry?.data?.Tag,
+      servants: entry?.data?.Servants?.docs,
+   });
+}
+
+const SECTIONS = {
+   main: TagsMain,
+   servants: TagsServants,
+};
+
+export default function EntryPage() {
+   const loaderdata = useLoaderData<typeof loader>();
+   const { entry } = loaderdata;
+
+   return <Entry customComponents={SECTIONS} customData={loaderdata} />;
+}
+
+const QUERY = gql`
+   query ($entryId: String!, $jsonEntryId: JSON) {
+      Tag(id: $entryId) {
+         id
+         name
+         slug
+         description
+         icon {
+            url
+         }
+      }
+      Servants(where: { tags: { equals: $jsonEntryId } }, limit: 1000) {
+         docs {
+            id
+            name
+            library_id
+            slug
+            icon {
+               url
+            }
+            class {
+               id
+               icon {
+                  url
+               }
+            }
+            star_rarity {
+               id
+               name
+            }
+            release_status {
+               id
+               name
+            }
+         }
+      }
+   }
+`;

--- a/app/_custom/routes/_site.c.tags+/components/Tags.Main.tsx
+++ b/app/_custom/routes/_site.c.tags+/components/Tags.Main.tsx
@@ -1,0 +1,26 @@
+import { Image } from "~/components/Image";
+
+export const TagsMain = ({ data }: any) => {
+   const tagdata = data?.tag;
+   const icon = tagdata.icon?.url;
+   const description = tagdata.description;
+
+   return (
+      <>
+         <div className="mb-3 rounded-md border border-color-sub p-3 text-center">
+            <Image
+               width={36}
+               height={36}
+               url={icon}
+               className="mx-auto"
+               options="aspect_ratio=1:1&height=80&width=80"
+            />
+
+            <div
+               className="whitespace-wrap"
+               dangerouslySetInnerHTML={{ __html: description }}
+            ></div>
+         </div>
+      </>
+   );
+};


### PR DESCRIPTION
- _Tags renamed to Tags
- Servant collection grid view links fixed from pokemon > servants
- Tag templating added with default 3-column sorting and individual filter/sorting support, corrected sort function behavior for collection relation columns.
![image](https://github.com/user-attachments/assets/9fee40c7-d1ff-4ab3-9efd-6ca90867ce0f)
