### PR TITLE
[grandorder] Material, CE, Quest Template Updates

### DIFF
--- a/app/_custom/routes/_site.c.craft-essences+/components/CraftEssences.Effect.tsx
+++ b/app/_custom/routes/_site.c.craft-essences+/components/CraftEssences.Effect.tsx
@@ -2,6 +2,7 @@ import type { CraftEssence as CraftEssenceType } from "payload/generated-custom-
 import { Image } from "~/components/Image";
 import { Link } from "@remix-run/react";
 import { SectionTitle } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/SectionTitle";
+import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/Tooltip";
 
 export function CraftEssencesEffect({ data: ce }: { data: CraftEssenceType }) {
    const dispData = [
@@ -33,6 +34,8 @@ export function CraftEssencesEffect({ data: ce }: { data: CraftEssenceType }) {
          url: "/c/cvs/" + ce?.cv?.id,
       },
    ];
+
+   const bonusItems = ce.effect_list?.map((a) => a.bonus_item)?.flat();
 
    return (
       <>
@@ -99,6 +102,39 @@ export function CraftEssencesEffect({ data: ce }: { data: CraftEssenceType }) {
                </>
             ))}
          </div>
+         {/* If Bonus Items Exist */}
+         {bonusItems?.length > 0 ? (
+            <>
+               <SectionTitle customTitle={"Drop Bonus Item"} />
+               <div className="flex items-center gap-1">
+                  {bonusItems.map((mat) => (
+                     <MaterialDisplay mat={mat} />
+                  ))}
+               </div>
+            </>
+         ) : null}
       </>
    );
 }
+
+const MaterialDisplay = ({ mat }: any) => {
+   return (
+      <>
+         <Tooltip key={mat?.id} placement="top">
+            <TooltipTrigger className="size-12 inline-block align-middle m-0.5">
+               <Link to={`/c/materials/${mat?.slug ?? mat?.id}`}>
+                  <Image
+                     height={60}
+                     width={60}
+                     className="size-12"
+                     url={mat?.icon?.url}
+                     alt={mat?.name}
+                     loading="lazy"
+                  />
+               </Link>
+            </TooltipTrigger>
+            <TooltipContent>{mat?.name}</TooltipContent>
+         </Tooltip>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.materials+/$entryId.tsx
+++ b/app/_custom/routes/_site.c.materials+/$entryId.tsx
@@ -74,6 +74,19 @@ const QUERY = gql`
                }
             }
          }
+         ce_With_Drop_Bonus {
+            id
+            slug
+            name
+            _rarity {
+               icon_frame {
+                  url
+               }
+            }
+            icon {
+               url
+            }
+         }
       }
       ascensionData: Servants(
          where: {

--- a/app/_custom/routes/_site.c.materials+/components/Materials.Main.tsx
+++ b/app/_custom/routes/_site.c.materials+/components/Materials.Main.tsx
@@ -1,10 +1,15 @@
 import { Image } from "~/components/Image";
+import { SectionTitle } from "~/routes/_site+/c_+/$collectionId_.$entryId/components/SectionTitle";
+import { Tooltip, TooltipTrigger, TooltipContent } from "~/components/Tooltip";
+import { Link } from "@remix-run/react";
 
 export function MaterialsMain({ data }: { data: any }) {
    const material = data?.entry?.data?.Material;
    const icon = material?.icon?.url;
    const desc = material?.description;
+   const bonusces = material?.ce_With_Drop_Bonus;
 
+   console.log(bonusces);
    return (
       <>
          <div className="bg-2-sub border border-color-sub shadow-sm shadow-1 rounded-lg p-4 flex items-center flex-col justify-center">
@@ -22,6 +27,50 @@ export function MaterialsMain({ data }: { data: any }) {
                />
             )}
          </div>
+
+         {/* If CEs give bonus for this item */}
+         {bonusces?.length > 0 ? (
+            <>
+               <SectionTitle customTitle={"Drop Bonus Craft Essences"} />
+               <div className="flex items-center gap-1">
+                  {bonusces.map((ce) => (
+                     <CEDisplay ce={ce} />
+                  ))}
+               </div>
+            </>
+         ) : null}
       </>
    );
 }
+
+const CEDisplay = ({ ce }: any) => {
+   const name = ce.name;
+   const frame = ce._rarity?.icon_frame?.url;
+   const icon = ce.icon?.url;
+
+   return (
+      <>
+         <Tooltip key={ce?.id} placement="top">
+            <TooltipTrigger className="size-12 inline-block align-middle relative">
+               <Link to={`/c/craft-essences/${ce?.slug ?? ce?.id}`}>
+                  <Image
+                     width={80}
+                     alt={name}
+                     url={frame}
+                     className="object-contain w-12 z-10 relative"
+                     loading="lazy"
+                  />
+                  <Image
+                     width={80}
+                     alt={name}
+                     url={icon}
+                     className="object-contain w-12 rounded-t-md absolute top-[1px] left-0"
+                     loading="lazy"
+                  />
+               </Link>
+            </TooltipTrigger>
+            <TooltipContent>{name}</TooltipContent>
+         </Tooltip>
+      </>
+   );
+};

--- a/app/_custom/routes/_site.c.quests+/components/Quests.Rewards.tsx
+++ b/app/_custom/routes/_site.c.quests+/components/Quests.Rewards.tsx
@@ -40,7 +40,7 @@ export function QuestsDrops({ data }: { data: any }) {
 }
 
 const RewardRow = ({ data, index }: any) => {
-   const collection_type = data.mat?.relationTo;
+   const collection_type = data.mat?.relationTo?.replace("_", "-");
    const icon = data.mat?.value?.icon?.url;
    const name = data.mat?.value?.name;
    const qty = data.qty;


### PR DESCRIPTION
Quests:
- Fixed links to craft essence and command code collection types to use dash instead of underscore in collection name

Materials:
- Added section to display CEs that provide a drop bonus for the given material.

CEs:
- Added section to display any bonus items that the CE boosts drop rate for.