### PR TITLE
[grandorder] Duplication to use timestamp instead of increment

### DIFF
--- a/app/_custom/collections/hooks/Duplicate_AppendIncrement.ts
+++ b/app/_custom/collections/hooks/Duplicate_AppendIncrement.ts
@@ -2,13 +2,12 @@ import type { BeforeDuplicate } from "payload/types";
 
 export const Duplicate_AppendIncrement: BeforeDuplicate<any> = ({ data }) => {
    var tempid = data?.id;
+   var timestampid = new Date().getTime();
    const last_num = parseInt(tempid.replace(/.*-/, ""));
    if (tempid.indexOf("-") > -1 && last_num) {
-      // If making clone of a clone, to avoid requerying the entire collection, will add timestamp as ID. Only the first clone will have -1.
-      var timestampid = new Date().getTime();
       tempid = tempid.replace(/\-[^-]*$/, "") + "-" + timestampid;
    } else {
-      tempid = tempid + "-1";
+      tempid = tempid + "-" + timestampid;
    }
    // Clean ID if invalid URI characters exist
    tempid = tempid.replace(/[^a-zA-Z0-9-_]/g, "_");


### PR DESCRIPTION
Cannot query payload within the BeforeDuplicate hook? Is this an oversight on Payload's part? This is the best workaround I can think of for now.