### PR TITLE
[grandorder] Mystic Code + Servant Collection Fixes

### DIFF
--- a/app/_custom/collections/mystic-code-skills.ts
+++ b/app/_custom/collections/mystic-code-skills.ts
@@ -3,80 +3,80 @@ import type { CollectionConfig } from "payload/types";
 import { isStaff } from "../../db/collections/users/users.access";
 
 export const MysticCodeSkills: CollectionConfig = {
-  slug: "mystic-code-skills",
-  labels: { singular: "Mystic-Code-Skill", plural: "Mystic-Code-Skills" },
-  admin: { group: "Custom", useAsTitle: "name" },
-  access: {
-    create: isStaff, //udpate in future to allow site admins as well
-    read: () => true,
-    update: isStaff, //udpate in future to allow site admins as well
-    delete: isStaff, //udpate in future to allow site admins as well
-  },
-  fields: [
-    {
-      name: "id",
-      type: "text",
-    },
-    {
-      name: "drupal_nid",
-      type: "text",
-    },
-    {
-      name: "name",
-      type: "text",
-    },
-    {
-      name: "path",
-      type: "text",
-    },
-    {
-      name: "cooldown",
-      type: "number",
-    },
-    {
-      name: "effect",
-      type: "textarea",
-    },
-    {
-      name: "effect_values",
-      type: "textarea",
-    },
-    {
-      name: "availability",
-      type: "relationship",
-      relationTo: "_availabilities",
-      hasMany: false,
-    },
-    {
-      name: "skill_image",
-      type: "relationship",
-      relationTo: "_skill-images",
-      hasMany: false,
-    },
-    {
-      name: "target",
-      type: "relationship",
-      relationTo: "_targets",
-      hasMany: false,
-    },
-    {
-      name: "type_specific",
-      type: "relationship",
-      relationTo: "_skill-classification-specifics",
-      hasMany: false,
-    },
-    {
-      name: "icon",
-      type: "upload",
-      relationTo: "images",
-    },
-    {
-      name: "slug",
-      type: "text",
-    },
-    {
-      name: "checksum",
-      type: "text",
-    },
-  ],
+   slug: "mystic-code-skills",
+   labels: { singular: "Mystic-Code-Skill", plural: "Mystic-Code-Skills" },
+   admin: { group: "Custom", useAsTitle: "name" },
+   access: {
+      create: isStaff, //udpate in future to allow site admins as well
+      read: () => true,
+      update: isStaff, //udpate in future to allow site admins as well
+      delete: isStaff, //udpate in future to allow site admins as well
+   },
+   fields: [
+      {
+         name: "id",
+         type: "text",
+      },
+      {
+         name: "drupal_nid",
+         type: "text",
+      },
+      {
+         name: "name",
+         type: "text",
+      },
+      {
+         name: "path",
+         type: "text",
+      },
+      {
+         name: "cooldown",
+         type: "number",
+      },
+      {
+         name: "effect",
+         type: "textarea",
+      },
+      {
+         name: "effect_values",
+         type: "textarea",
+      },
+      {
+         name: "availability",
+         type: "relationship",
+         relationTo: "_release-statuses",
+         hasMany: false,
+      },
+      {
+         name: "skill_image",
+         type: "relationship",
+         relationTo: "_skill-images",
+         hasMany: false,
+      },
+      {
+         name: "target",
+         type: "relationship",
+         relationTo: "_targets",
+         hasMany: false,
+      },
+      {
+         name: "type_specific",
+         type: "relationship",
+         relationTo: "_skill-classification-specifics",
+         hasMany: false,
+      },
+      {
+         name: "icon",
+         type: "upload",
+         relationTo: "images",
+      },
+      {
+         name: "slug",
+         type: "text",
+      },
+      {
+         name: "checksum",
+         type: "text",
+      },
+   ],
 };

--- a/app/_custom/collections/servants.ts
+++ b/app/_custom/collections/servants.ts
@@ -530,6 +530,10 @@ export const Servants: CollectionConfig = {
                relationTo: "traits",
                hasMany: true,
             },
+            {
+               name: "trait_notes",
+               type: "textarea",
+            },
          ],
       },
       {


### PR DESCRIPTION
- Changed availability to use JP/NA status instead of servant availability for Mystic Code Skills
- Added Trait Notes field for describing special trait conditions such as ascension