### PR TITLE
[grandorder] Fixed Servant Interlude Section + NPC Servant Display

### DIFF
--- a/app/_custom/routes/_site.c.servants+/components/Servants.Interludes.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.Interludes.tsx
@@ -28,6 +28,7 @@ export const Interludes = ({ data }: { data: any }) => {
                <TableBody>
                   {interlude_quests?.map((int: any, index: number) => {
                      const questname = int.quest?.name;
+                     const questnick = int.quest_nickname;
                      const questid = int.quest?.id;
                      const chaptername = int.chapter?.name;
                      const ascension = int.ascension;
@@ -40,13 +41,17 @@ export const Interludes = ({ data }: { data: any }) => {
                         <TableRow key={index}>
                            <TableCell>
                               <div>
-                                 {available}
-                                 <a
-                                    className="text-blue-500"
-                                    href={`/c/quests/${questid}`}
-                                 >
-                                    {questname}
-                                 </a>
+                                 {available}{" "}
+                                 {questid ? (
+                                    <a
+                                       className="text-blue-500"
+                                       href={`/c/quests/${questid}`}
+                                    >
+                                       {questnick}
+                                    </a>
+                                 ) : (
+                                    <>{questnick}</>
+                                 )}
                               </div>
                               <div className="text-xs my-1">
                                  <span className="font-bold mr-1">

--- a/app/_custom/routes/_site.c.servants+/components/Servants.NoblePhantasm.tsx
+++ b/app/_custom/routes/_site.c.servants+/components/Servants.NoblePhantasm.tsx
@@ -20,23 +20,23 @@ export function NoblePhantasm({ data }: { data: any }) {
 }
 
 const NoblePhantasmDisplay = ({ np }: any) => {
-   const np_name = np.name;
-   const np_description = np.description;
-   const np_overcharge = np.description_overcharge;
-   const np_card_icon = np.card_type?.icon?.url;
-   const np_rank = np.rank;
-   const video_link = np.video_link
+   const np_name = np?.name;
+   const np_description = np?.description;
+   const np_overcharge = np?.description_overcharge;
+   const np_card_icon = np?.card_type?.icon?.url;
+   const np_rank = np?.rank;
+   const video_link = np?.video_link
       ? np.video_link.split("=")?.[1]?.replace(/\?.*/g, "") +
         (np.video_link?.split("=")?.[2]
            ? "?start=" + np.video_link?.split("=")?.[2]
            : "")
       : null;
    // const np_sub = np.sub_name;
-   const np_classification = np.np_classification?.name;
-   const np_hit_count = np.hit_count;
-   const np_effect_list = np.effect_list;
-   const np_effect_list_overcharge = np.effect_list_overcharge;
-   const unlock = np.unlock_condition;
+   const np_classification = np?.np_classification?.name;
+   const np_hit_count = np?.hit_count;
+   const np_effect_list = np?.effect_list;
+   const np_effect_list_overcharge = np?.effect_list_overcharge;
+   const unlock = np?.unlock_condition;
    const [open, setOpen] = useState(false);
 
    return (
@@ -228,7 +228,7 @@ const NoblePhantasmDisplay = ({ np }: any) => {
             ) : null}
          </div>
 
-         {np.np_upgrades?.map((npupg: any, int: number) => (
+         {np?.np_upgrades?.map((npupg: any, int: number) => (
             <NoblePhantasmDisplay key={int} np={npupg} />
          ))}
       </>


### PR DESCRIPTION
- NPC Enemy / Boss Servant pages now display properly.
- Interlude section swapped to use Quest Nickname instead of Quest name in case quest name is missing.