### PR TITLE
[grandorder] Collection Update - servant-skill-effects created

### DIFF
--- a/app/_custom/collections/_class-score-nodes.ts
+++ b/app/_custom/collections/_class-score-nodes.ts
@@ -58,7 +58,7 @@ export const _ClassScoreNodes: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {

--- a/app/_custom/collections/append-skills.ts
+++ b/app/_custom/collections/append-skills.ts
@@ -45,7 +45,7 @@ export const AppendSkills: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {
@@ -56,7 +56,7 @@ export const AppendSkills: CollectionConfig = {
             },
             {
                name: "value_single",
-               type: "number"
+               type: "number",
             },
             {
                name: "value_type",
@@ -65,47 +65,57 @@ export const AppendSkills: CollectionConfig = {
                options: [
                   {
                      label: "flat",
-                     value: "flat"
+                     value: "flat",
                   },
                   {
                      label: "percent",
-                     value: "percent"
-                  }
-               ]
+                     value: "percent",
+                  },
+               ],
             },
             {
                name: "turns",
-               type: "number"
+               type: "number",
             },
             {
                name: "times",
-               type: "number"
+               type: "number",
             },
             {
                name: "effect_condition",
                type: "relationship",
-               relationTo: ["_alignments","attributes","_buff-categories","_classes","_command-cards","_enemy-traits","_field-types","_status-effects","traits"],
+               relationTo: [
+                  "_alignments",
+                  "attributes",
+                  "_buff-categories",
+                  "_classes",
+                  "_command-cards",
+                  "_enemy-traits",
+                  "_field-types",
+                  "_status-effects",
+                  "traits",
+               ],
                hasMany: true,
             },
             {
                name: "effect_on_damage_turns",
-               type: "number"
+               type: "number",
             },
             {
                name: "effect_on_damage_times",
-               type: "number"
+               type: "number",
             },
             {
                name: "values_per_level",
                type: "number",
-               hasMany: true
+               hasMany: true,
             },
             {
                name: "chance_per_level",
                type: "number",
-               hasMany: true
+               hasMany: true,
             },
-         ]
+         ],
       },
       {
          name: "drupal_nid",

--- a/app/_custom/collections/class-skills.ts
+++ b/app/_custom/collections/class-skills.ts
@@ -41,7 +41,7 @@ export const ClassSkills: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {

--- a/app/_custom/collections/index.ts
+++ b/app/_custom/collections/index.ts
@@ -31,8 +31,8 @@ import { _NPClassifications } from "./_np-classifications";
 import { _QuestTypes } from "./_quest-types";
 import { _Rarities } from "./_rarities";
 import { _ReleaseStatuses } from "./_release-statuses";
+import { ServantSkillEffects } from "./servant-skill-effects";
 import { _SimulatorPools } from "./_simulator-pools";
-import { _SkillClassificationSpecifics } from "./_skill-classification-specifics";
 import { _SkillImages } from "./_skill-images";
 import { _StarRarities } from "./_star-rarities";
 import { _StatusEffects } from "./_status-effects";
@@ -108,8 +108,8 @@ export const CustomCollections = [
    _QuestTypes,
    _Rarities,
    _ReleaseStatuses,
+   ServantSkillEffects,
    _SimulatorPools,
-   _SkillClassificationSpecifics,
    _SkillImages,
    _StarRarities,
    _StatusEffects,

--- a/app/_custom/collections/mystic-code-skills.ts
+++ b/app/_custom/collections/mystic-code-skills.ts
@@ -62,7 +62,7 @@ export const MysticCodeSkills: CollectionConfig = {
       {
          name: "type_specific",
          type: "relationship",
-         relationTo: "_skill-classification-specifics",
+         relationTo: "servant-skill-effects",
          hasMany: false,
       },
       {

--- a/app/_custom/collections/noble-phantasms.ts
+++ b/app/_custom/collections/noble-phantasms.ts
@@ -90,7 +90,7 @@ export const NoblePhantasms: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {
@@ -156,7 +156,7 @@ export const NoblePhantasms: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {

--- a/app/_custom/collections/servant-skill-effects.ts
+++ b/app/_custom/collections/servant-skill-effects.ts
@@ -2,9 +2,12 @@ import type { CollectionConfig } from "payload/types";
 
 import { isStaff } from "../../db/collections/users/users.access";
 
-export const _SkillClassificationSpecifics: CollectionConfig = {
-   slug: "_skill-classification-specifics",
-   labels: { singular: "_Skill-Classification-Specific", plural: "_Skill-Classification-Specifics" },
+export const ServantSkillEffects: CollectionConfig = {
+   slug: "servant-skill-effects",
+   labels: {
+      singular: "Servant-Skill-Effect",
+      plural: "Servant-Skill-Effects",
+   },
    admin: {
       group: "Custom",
       useAsTitle: "name",

--- a/app/_custom/collections/servant-skills.ts
+++ b/app/_custom/collections/servant-skills.ts
@@ -61,7 +61,7 @@ export const ServantSkills: CollectionConfig = {
             {
                name: "effect",
                type: "relationship",
-               relationTo: "_skill-classification-specifics",
+               relationTo: "servant-skill-effects",
                hasMany: false,
             },
             {


### PR DESCRIPTION
Replacing _skill-classification-specifics collection with servant-skill-effects collection. Updated all relationships referencing collection.

This update is a precursor to adding a new searchable / sortable Servant Skill Effects collection entity page similar to Craft Essence Effects collection.